### PR TITLE
fix bi value parse bug introduced in 4578ba4

### DIFF
--- a/ether_ipApp/src/devEtherIP.c
+++ b/ether_ipApp/src/devEtherIP.c
@@ -206,8 +206,14 @@ static eip_bool get_bits(dbCommon *rec, size_t bits, epicsUInt32 *rval)
     }
     /* Fetch bits from BOOL array.
      * #1 directly (faster for BI case), rest in loop */
-    if ((value & 0x1) & mask)
-        *rval = 1;
+    if (bits == 1) {
+        if (value & mask)
+           *rval = 1;
+    } else {
+        /* in case the mask is 0xFF */
+        if ((value & 0x1) & mask)
+           *rval = 1;
+    }
     for (i=1/*!*/; i<bits; ++i)
     {
         mask <<= 1;


### PR DESCRIPTION
After commit 4578ba4 (4/11/2025), it fails to parse the bi record when it is the bit # > 0. e.g.

```julia
record(bi, "ECH_HVPS:Light:Org_Sts") {
    field(DTYP, "EtherIP")
    field(SCAN, ".5 second")
    field(INP, "@$(PLC) PSHCS_PLC_RIO4_bi[0] B 1")        # <-- bit # is 1
}
```

If the value fetched from PLC is 2 (0b0010), the mask is also 2 (0b0010) in above record, then in get_bits() function, the code 

```c
    if ((value & 0x1) & mask)
       *rval = 1;
```

will set the `*rval` as 0. However, in this case, the RVAL should be 1.

Below is the change in this PR:

```c
    if (bits == 1) {
        if (value & mask)
           *rval = 1;
    } else {
        /* in case the mask is 0xFF */
        if ((value & 0x1) & mask)
           *rval = 1;
    }
```

